### PR TITLE
Give PSPP access to user home directory.

### DIFF
--- a/org.gnu.pspp.yml
+++ b/org.gnu.pspp.yml
@@ -11,6 +11,8 @@ finish-args:
   - --socket=wayland
   - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
+  # Access to file system from syntax files
+  - --filesystem=home
 modules:
   - name: spread-sheet-widget
     buildsystem: autotools


### PR DESCRIPTION
PSPP reads and executes syntax files that can access files by name. Without this access, those syntax files can't usefully read or write user data, which makes PSPP hardly useful.  This commit fixes the problem.