### PR TITLE
Improve cleanup commands

### DIFF
--- a/org.gnu.pspp.yml
+++ b/org.gnu.pspp.yml
@@ -13,6 +13,18 @@ finish-args:
   - --filesystem=xdg-run/gvfsd
   # Access to file system from syntax files
   - --filesystem=home
+cleanup:
+ - /include
+ - /lib/girepository-1.0
+ - /lib/pkgconfig
+ - /share/aclocal
+ - /share/doc
+ - /share/gir-1.0
+ - /share/info
+ - /share/man
+ - /share/vala
+ - '*.la'
+ - '*.a'
 modules:
   - name: spread-sheet-widget
     buildsystem: autotools


### PR DESCRIPTION
Flatpak size reduced from 64.4 MB to 14.8 MB.

This PR removes the files that are listed in the following text file.

[removed-files.txt](https://github.com/user-attachments/files/25751127/removed-files.txt)
